### PR TITLE
Hacked buffer memory alignment for the iOS simulator

### DIFF
--- a/src/vk_mem_alloc.h
+++ b/src/vk_mem_alloc.h
@@ -15196,6 +15196,10 @@ void VmaAllocator_T::GetBufferMemoryRequirements(
         requiresDedicatedAllocation = false;
         prefersDedicatedAllocation  = false;
     }
+#if TARGET_OS_SIMULATOR
+    // See: https://github.com/KhronosGroup/MoltenVK/issues/1250
+    memReq.alignment = 256;
+#endif
 }
 
 void VmaAllocator_T::GetImageMemoryRequirements(


### PR DESCRIPTION
When running in the iOS simulator, constant buffer offsets must be
aligned to 256 bytes. `vkGetBufferMemoryRequirements` is reporting the
wrong alignement in this case. see: https://github.com/KhronosGroup/MoltenVK/issues/1250